### PR TITLE
fix:mprotect fail in android 15

### DIFF
--- a/app/src/main/cpp/CMakeLists.txt
+++ b/app/src/main/cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ target_compile_features(${TARGET} PUBLIC c_std_17)
 target_compile_options(${TARGET} PUBLIC -std=c17 -Weverything -Werror -Wno-unused-macros)
 target_include_directories(${TARGET} PUBLIC hookee)
 target_link_libraries(${TARGET} log)
-
+target_link_options(${TARGET} PRIVATE "-Wl,-z,max-page-size=16384")
 # libhookee2.so
 set(TARGET "hookee2")
 file(GLOB SRC hookee2/*.c)
@@ -27,6 +27,7 @@ target_compile_features(${TARGET} PUBLIC c_std_17)
 target_compile_options(${TARGET} PUBLIC -std=c17 -Weverything -Werror)
 target_include_directories(${TARGET} PUBLIC hookee2)
 target_link_libraries(${TARGET} log)
+target_link_options(${TARGET} PRIVATE "-Wl,-z,max-page-size=16384")
 
 # libunittest.so
 set(TARGET "unittest")
@@ -36,3 +37,4 @@ target_compile_features(${TARGET} PUBLIC c_std_17)
 target_compile_options(${TARGET} PUBLIC -std=c17 -Weverything -Werror)
 target_include_directories(${TARGET} PUBLIC unittest hookee)
 target_link_libraries(${TARGET} log hookee shadowhook::shadowhook)
+target_link_options(${TARGET} PRIVATE "-Wl,-z,max-page-size=16384")

--- a/shadowhook/src/main/cpp/CMakeLists.txt
+++ b/shadowhook/src/main/cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ target_compile_features(${TARGET} PUBLIC c_std_17)
 target_compile_options(${TARGET} PUBLIC -std=c17 -Weverything -Werror)
 target_include_directories(${TARGET} PUBLIC . include arch/${ARCH} common third_party/xdl third_party/bsd third_party/lss)
 target_link_libraries(${TARGET} log)
+target_link_options(${TARGET} PRIVATE "-Wl,-z,max-page-size=16384")
 
 if(USEASAN)
     target_compile_options(${TARGET} PUBLIC -fsanitize=address -fno-omit-frame-pointer)

--- a/shadowhook/src/main/cpp/common/sh_util.h
+++ b/shadowhook/src/main/cpp/common/sh_util.h
@@ -40,8 +40,8 @@
 #define SH_UTIL_ALIGN_START(x, align) ((uintptr_t)(x) & ~((uintptr_t)(align)-1))
 #define SH_UTIL_ALIGN_END(x, align)   (((uintptr_t)(x) + (uintptr_t)(align)-1) & ~((uintptr_t)(align)-1))
 
-#define SH_UTIL_PAGE_START(x) SH_UTIL_ALIGN_START(x, 0x1000)
-#define SH_UTIL_PAGE_END(x)   SH_UTIL_ALIGN_END(x, 0x1000)
+#define SH_UTIL_PAGE_START(x) SH_UTIL_ALIGN_START(x, getpagesize())
+#define SH_UTIL_PAGE_END(x)   SH_UTIL_ALIGN_END(x, getpagesize())
 
 #define SH_UTIL_IS_THUMB(addr)   ((addr)&1u)
 #define SH_UTIL_CLEAR_BIT0(addr) ((addr)&0xFFFFFFFE)
@@ -101,3 +101,4 @@ struct tm *sh_util_localtime_r(const time_t *timep, long gmtoff, struct tm *resu
 
 size_t sh_util_vsnprintf(char *buffer, size_t buffer_size, const char *format, va_list args);
 size_t sh_util_snprintf(char *buffer, size_t buffer_size, const char *format, ...);
+


### PR DESCRIPTION
link:https://developer.android.com/guide/practices/page-sizes?hl=zh-cn#groovy_1

**before:**
Fatal signal 11 (SIGSEGV), code 2 (SEGV_ACCERR), fault addr 0x784a80a20864 in tid 6104 (adowhook.sample), pid 6104 (adowhook.sample)
Cmdline: com.bytedance.shadowhook.sample
pid: 6104, tid: 6104, name: adowhook.sample  >>> com.bytedance.shadowhook.sample <<<

and: shadowhook: hook_sym_name(linker64, __dl__Z9do_dlopenPKciPK17android_dlextinfoPKv, 0x784a8099dff8) FAILED. 5 - MProtect failed

**after fix**
shadowhook: hook_sym_name(libhookee2.so, test_hook_before_dlopen_1, 0x784a809d9ce8) OK. return: 0xb400784c3894e3c0. 1 - Pending task
shadowhook: hook_sym_name(libhookee2.so, test_hook_before_dlopen_2, 0x784a809d9eb0) ...
shadowhook: hook_sym_name(libhookee2.so, test_hook_before_dlopen_2, 0x784a809d9eb0) OK. return: 0xb400784c389441e0. 1 - Pending task
