### PR TITLE
避免sh_linker_soinfo_memory_scan_pre执行成功后再次进入sh_linker_soinfo_memory_scan_pre

### DIFF
--- a/shadowhook/src/main/cpp/sh_linker.c
+++ b/shadowhook/src/main/cpp/sh_linker.c
@@ -404,8 +404,10 @@ void shadowhook_proxy_android_linker_soinfo_call_constructors(void *soinfo) {
     }
   } else {
     if (__predict_true(gettid() == scan_tid)) {
-      // do pre-memory-scan
-      if (0 == sh_linker_soinfo_memory_scan_pre(soinfo)) do_memory_scan_pre_ok = true;
+      if (!__atomic_load_n(&sh_linker_soinfo_offset_scan_ok, __ATOMIC_RELAXED)) {
+        // do pre-memory-scan
+        if (0 == sh_linker_soinfo_memory_scan_pre(soinfo)) do_memory_scan_pre_ok = true;
+      }
     }
   }
 


### PR DESCRIPTION
```
  __atomic_store_n(&sh_linker_soinfo_offset_scan_tid, gettid(), __ATOMIC_RELEASE);
  void *handle = dlopen(SH_LINKER_SHADOWHOOK_NOTHING_BASE_NAME, RTLD_NOW);
  if (__predict_true(NULL != handle)) dlclose(handle);
  __atomic_store_n(&sh_linker_soinfo_offset_scan_tid, 0, __ATOMIC_RELEASE);
```
在dlopen和dlclose之间可能会被插入其他指令，比如：其他线程的一个dlopen操作，dlopen和dlclose都是带锁的，如果插入其他线程的一个dlopen操作，本线程的dlclose会等待直到可以获到锁。所以sh_linker_soinfo_offset_scan_tid的赋值操作也会被延迟，造成sh_linker_soinfo_memory_scan_pre执行成功后再次进入sh_linker_soinfo_memory_scan_pre。