### PR TITLE
Correct dump-records signal-safety documentation

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -1703,7 +1703,7 @@ void shadowhook_dump_records(int fd, uint32_t item_flags);
 
 - The `item_flags` parameter is used to specify which operation record items to retrieve. You can use `|` to concatenate the flags defined above; you can also specify `SHADOWHOOK_RECORD_ITEM_ALL` to get **all** operation record items.
 - The `shadowhook_get_records()` API returns a buffer allocated with `malloc()` containing the operation records. **Please use `free()` to release after external use.**
-- The `shadowhook_dump_records()` API writes operation records to the file descriptor specified by the `fd` parameter. **This API is async-signal-safe and can be called in signal handlers.**
+- The `shadowhook_dump_records()` API writes operation records to the file descriptor specified by the `fd` parameter. **This API is not async-signal-safe and must not be called from an asynchronous signal handler.**
 
 ## Parsing Operation Records
 

--- a/doc/manual.zh-CN.md
+++ b/doc/manual.zh-CN.md
@@ -1703,7 +1703,7 @@ void shadowhook_dump_records(int fd, uint32_t item_flags);
 
 - `item_flags` 参数用于指定需要获取哪些操作记录项，可以用 `|` 拼接上面定义的 flag；也可以指定 `SHADOWHOOK_RECORD_ITEM_ALL` 以获取**所有**的操作记录项。
 - `shadowhook_get_records()` API 返回一个用 `malloc()` 分配的 buffer，其中包含了操作记录。**外部使用完后请使用 free()` 释放。**
-- `shadowhook_dump_records()` API 会向 `fd` 参数所指的文件描述符写出操作记录。**这个 API 是异步信号安全的，可以在信号处理函数中调用。**
+- `shadowhook_dump_records()` API 会向 `fd` 参数所指的文件描述符写出操作记录。**这个 API 不是异步信号安全的，不得在异步信号处理函数中调用。**
 
 ## 解析操作记录
 


### PR DESCRIPTION
This PR fixes #122

## Problem

Both English and Chinese manuals say shadowhook_dump_records is async-signal-safe. Its implementation locks recorder mutexes and therefore cannot safely run in an asynchronous signal handler.

## Changes

Update both language versions to warn callers not to invoke the API from an asynchronous signal handler.

## Verification

- Checked every tracked Markdown file to ensure the old positive safety claim is absent.
- Verified that both manuals contain the matching negative warning.
- Ran git diff --check.